### PR TITLE
Rename text_num_tokens to text_vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ from clap.clap import CLAP
 
 key1, key2 = random.split(random.PRNGKey(0), 2)
 
-text = random.randint(key1, (2, 16,), 0, 10000)
+text = random.randint(key1, (2, 16,), 0, 256)
 audio = random.uniform(key1, (2, 8, 512))
 
 model = CLAP(
-    text_num_tokens = 10000,
+    text_vocab = 256,
     text_dim = 512,
     text_depth = 6,
     text_heads = 8,

--- a/clap/clap.py
+++ b/clap/clap.py
@@ -96,7 +96,7 @@ class Transformer(nn.Module):
         return x
 
 class CLAP(nn.Module):
-    text_num_tokens: int
+    text_vocab: int
     text_dim: int
     text_depth: int
     text_heads: int
@@ -113,9 +113,9 @@ class CLAP(nn.Module):
 
     @nn.compact
     def __call__(self, text, audio, return_loss = True):
-        b, num_tokens, text_dim = text.shape[0], self.text_num_tokens, self.text_dim
+        b, text_vocab, text_dim = text.shape[0], self.text_vocab, self.text_dim
 
-        to_text_tokens = nn.Embed(num_embeddings = num_tokens, features = text_dim)
+        to_text_tokens = nn.Embed(num_embeddings = text_vocab, features = text_dim)
         temp = self.param('temperature', self.temp_init, tuple())
 
         text = to_text_tokens(text)


### PR DESCRIPTION
Minor edit that'll ease my own confusion :) 

The size of the vocab (which, in the case of byte-level tokenization, would be 256) is changed here to be `text_vocab`.