### PR TITLE
Switch datasets to TFRecords

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,6 @@ audio = random.uniform(key1, (2, 8, 512))
 text_mask = np.ones((2, 16), dtype = bool)
 audio_mask = np.ones((2, 8), dtype = bool)
 
-audio_config = {
-    'kind': 'vit', 
-    'depth': 8, 
-    'dim': 512, 
-    'heads': 8, 
-    'patch_shape': [4, 80], 
-    'projection_dim': 512, 
-    'rotary_qk': True,
-}
-
 text_config = {
     'kind': 'transformer',
     'depth': 8,
@@ -49,6 +39,16 @@ text_config = {
     'heads': 8,
     'vocab': 256,
     'projection_dim': 512,
+    'rotary_qk': True,
+}
+
+audio_config = {
+    'kind': 'vit', 
+    'depth': 8, 
+    'dim': 512, 
+    'heads': 8, 
+    'patch_shape': [4, 80], 
+    'projection_dim': 512, 
     'rotary_qk': True,
 }
 

--- a/clap/__init__.py
+++ b/clap/__init__.py
@@ -1,3 +1,3 @@
 from .models import CLAP
-from .datasets import CaptionedAudioDataset, CaptionedAudioMetadataset, tokenize
+from .datasets import PairTextSpectrogramTFRecords
 from .trunks import Transformer, ViT, TNT, CaiT, MLPMixer

--- a/clap/datasets.py
+++ b/clap/datasets.py
@@ -7,7 +7,6 @@ from itertools import cycle, islice, chain
 from einops import rearrange
 
 import torch.nn.functional as F
-from torch.utils.data import Dataset, TensorDataset, ConcatDataset, IterableDataset
 
 
 class PairTextSpectrogramTFRecords(object):
@@ -54,75 +53,6 @@ class PairTextSpectrogramTFRecords(object):
 
         tfrecord_writer.close()
     
-
-class PairTextSpectrogramDataset(Dataset):
-    def __init__(self, folder, max_audio_len=2048, max_text_len=256):
-        self.paths = [path for path in Path(folder).glob("*.pt")]
-        self.max_audio_len = max_audio_len
-        self.max_text_len = max_text_len
-
-    def __len__(self):
-        return len(self.paths)
-
-    def __getitem__(self, idx):
-        max_audio_len, max_text_len = self.max_audio_len, self.max_text_len
-
-        path = self.paths[idx]
-        data = torch.load(path)
-
-        audio, text = data["audio"], data["text"]
-        audio = audio[:max_audio_len]
-        text = text[:max_text_len]
-
-        audio_mask = torch.ones(audio.shape[:-1]).bool()
-        text_mask = torch.ones_like(text).bool()
-
-        return audio, audio_mask, text, text_mask
-
-
-def pair_text_spectrogram_dataset_collate_fn(batch):
-    max_audio_len = 2048
-    max_text_len = 256
-
-    padded_batch = []
-    for audio, audio_mask, text, text_mask in batch:
-        audio_len = audio.shape[0]
-        text_len = text.shape[0]
-        audio_pad_len = max_audio_len - audio_len
-        if audio_pad_len < 0:
-            raise ValueError("Audio clip too long")
-        text_pad_len = max_text_len - text_len
-        if text_pad_len < 0:
-            raise ValueError("Text caption too long")
-
-        if audio_pad_len > 0:
-            audio = F.pad(audio, (0, 0, audio_pad_len, 0), value=0.0)
-            audio_mask = F.pad(audio_mask, (audio_pad_len, 0), value=False)
-
-        if text_pad_len > 0:
-            text = F.pad(text, (text_pad_len, 0), value=0.0)
-            text_mask = F.pad(text_mask, (text_pad_len, 0), value=False)
-
-        # Add trailing dimension of 1, since mono audio
-        audio = rearrange(audio, "t c -> t c ()")
-
-        padded_batch.append((audio, audio_mask, text, text_mask))
-
-    output = tuple(map(lambda t: torch.stack(t).numpy(), zip(*padded_batch)))
-    return output
-
-
-def tokenize(text, pad_to=256):
-    # Padding token is 0, the null byte
-    tokens = torch.zeros(pad_to, dtype=torch.uint8)
-    # Truncate to context window size on the right if need be
-    for i, byte in enumerate(text.encode("utf-8")):
-        if i < pad_to:
-            tokens[i] = int(byte)
-        else:
-            break
-    return torch.tensor(tokens)
-
 
 def roundrobin(*iterables):
     "roundrobin('ABC', 'D', 'EF') --> A D E B F C"

--- a/clap/datasets.py
+++ b/clap/datasets.py
@@ -2,105 +2,11 @@ import glob
 import torch
 from pathlib import Path
 
-import lm_dataformat as lmd
 from itertools import cycle, islice, chain
 from einops import rearrange
 
 import torch.nn.functional as F
 from torch.utils.data import Dataset, TensorDataset, ConcatDataset, IterableDataset
-
-
-class CaptionedAudioMetadataset(IterableDataset):
-    def __init__(self, path_pairs, lazy=False):
-        self.datasets = [
-            CaptionedAudioDataset(captions_path, spectrograms_path, lazy=lazy)
-            for (captions_path, spectrograms_path) in path_pairs
-        ]
-
-    def __iter__(self):
-        def roundrobin(datasets):
-            num_active = len(datasets)
-            nexts = cycle(iter(it).__next__ for it in datasets)
-            while num_active:
-                try:
-                    for next in nexts:
-                        yield next()
-                except StopIteration:
-                    # Remove the iterator we just exhausted from the cycle.
-                    num_active -= 1
-                    nexts = cycle(islice(nexts, num_active))
-
-        iterator = roundrobin(self.datasets)
-
-        return iterator
-
-
-class CaptionedAudioDataset(IterableDataset):
-    def __init__(self, captions_path, spectrograms_path, lazy=False):
-        self.lazy = lazy
-        if self.lazy:
-            # Warning: The lazy path does not check whether the cpation metadata
-            # links it to the spectrogram. It assumes that the specrogram data,
-            # read from the files from the path in sorted order, loaded in as
-            # tensors, follows the exact same ordering as the LMD-encoded captions.
-            self.captions = lmd.Reader(captions_path).stream_data(get_meta=False)
-            self.spectrograms = SpectrogramLazyDataset(spectrograms_path)
-        else:
-            self.captions = lmd.Reader(captions_path).stream_data(get_meta=True)
-            self.spectrograms = SpectrogramDataset(spectrograms_path)
-
-    def __iter__(self):
-        if self.lazy:
-            iterator = (
-                (tokenize(text), spectrogram)
-                for ((text, _), spectrogram) in zip(self.captions, self.spectrograms)
-            )
-        else:
-            iterator = (
-                (tokenize(text), self.spectrograms[meta["index"]])
-                for (text, meta) in self.captions
-            )
-        return iterator
-
-
-class SpectrogramDataset(Dataset):
-    def __init__(self, path):
-        self.shard_paths = sorted(glob.glob(f"{path}/*.pt"))
-        self.data = ConcatDataset(
-            [SpectrogramDatasetShard(shard_path) for shard_path in self.shard_paths]
-        )
-
-    def __len__(self):
-        return len(self.data)
-
-    def __getitem__(self, idx):
-        return self.data[idx]
-
-
-class SpectrogramLazyDataset(IterableDataset):
-    def __init__(self, path):
-        self.shard_paths = sorted(glob.glob(f"{path}/*.pt"))
-
-    def __iter__(self):
-        def lazy_shard_loader():
-            for shard_path in self.shard_paths:
-                self.shard_data = SpectrogramDatasetShard(shard_path)
-                for example in self.shard_data:
-                    yield example
-
-        return lazy_shard_loader()
-
-
-class SpectrogramDatasetShard(Dataset):
-    def __init__(self, path):
-        self.dataset_shard = TensorDataset(torch.load(path))
-
-    def __len__(self):
-        # Layout is [examples, frames, channels]
-        return len(self.dataset_shard)
-
-    def __getitem__(self, idx):
-        return self.dataset_shard[idx]
 
 
 class PairTextSpectrogramDataset(Dataset):
@@ -129,11 +35,7 @@ class PairTextSpectrogramDataset(Dataset):
 
 
 def pair_text_spectrogram_dataset_collate_fn(batch):
-    audios = [el[0] for el in batch]
-    texts = [el[2] for el in batch]
-    # max_audio_len = max([audio.shape[0] for audio in audios]) # Should probably pad to a fixed length
     max_audio_len = 2048
-    # max_text_len = max([text.shape[0] for text in texts]) # Should probably pad to a fixed length
     max_text_len = 256
 
     padded_batch = []

--- a/clap/datasets.py
+++ b/clap/datasets.py
@@ -9,41 +9,49 @@ from einops import rearrange
 import torch.nn.functional as F
 from torch.utils.data import Dataset, TensorDataset, ConcatDataset, IterableDataset
 
-def to_tfrecords(data, fname="data.tfrecord"):
+
+def to_tfrecords(spectrograms, captions, fname="data.tfrecord"):
     tfrecord_writer = tf.io.TFRecordWriter(fname)
-    for (spectrogram, caption) in data:
+    for (spectrogram, caption) in zip(spectrograms, captions):
         example = tf.train.Example(features=tf.train.Features(feature={
-            'spectrogram-shape': tf.train.Feature(int64_list=tf.train.Int64List(value=spectrogram.shape)),
-            'spectrogram': tf.train.Feature(float_list=tf.train.FloatList(value=spectrogram.flatten())),
-            'text': tf.train.Feature(bytes_list=tf.train.BytesList(value=[caption.encode('utf-8')])),
+            'audio': tf.train.Feature(float_list=tf.train.FloatList(value=spectrogram.flatten())),
+            'text': tf.train.Feature(int64_list=tf.train.Int64List(value=[*caption.encode('utf-8')])),
         }))
         tfrecord_writer.write(example.SerializeToString())
 
     tfrecord_writer.close()
 
 class PairTextSpectrogramTFRecords(object):
-    def __init__(self, local_or_gcs_path, batch_size, prefetch_size=0, max_audio_len=2048, max_text_len=256):
+    def __init__(self, local_or_gcs_path, batch_size, prefetch_size=0, mel_bins=80, max_audio_len=2048, max_text_len=256):
+        self.mel_bins = mel_bins
+        self.max_audio_len = max_audio_len
+        self.max_text_len = max_text_len
+
         files = tf.data.TFRecordDataset.list_files(local_or_gcs_path + '/*.tfrecord', shuffle=False)
         dataset = tf.data.TFRecordDataset(files)
         dataset = dataset.map(self.deserialize_tf_record)
-        dataset = dataset.as_numpy_iterator()
-        dataset = dataset.batch(batch_size)
+        dataset = dataset.padded_batch(batch_size, padded_shapes={
+            'audio': (max_audio_len, mel_bins),
+            'text': (max_text_len),
+        })
         dataset = dataset.prefetch(prefetch_size)
+        dataset = dataset.as_numpy_iterator()
         self.dataset = dataset
-        self.max_audio_len = max_audio_len
-        self.max_text_len = max_text_len
+
+    def files(self):
+        return self.files
     
-    @staticmethod
-    def deserialize_tf_record(record):
+    def __iter__(self):
+        return self.dataset
+
+    def deserialize_tf_record(self, record):
         tfrecord_format = {
-            'spectrogram-shape': tf.io.FixedLenSequenceFeature((), dtype=tf.int64, allow_missing=True),
-            'spectrogram': tf.io.FixedLenSequenceFeature((), dtype=tf.float32, allow_missing=True),
-            'text': tf.io.FixedLenFeature([], tf.string),
+            'spectrogram': tf.io.FixedLenSequenceFeature((self.mel_bins,), dtype=tf.float32, allow_missing=True),
+            'text': tf.io.FixedLenSequenceFeature([], dtype=tf.int64, allow_missing=True),
         }
 
         features_tensor = tf.io.parse_single_example(record, tfrecord_format)
         return features_tensor
-
     
 
 class PairTextSpectrogramDataset(Dataset):

--- a/clap/datasets.py
+++ b/clap/datasets.py
@@ -10,17 +10,6 @@ import torch.nn.functional as F
 from torch.utils.data import Dataset, TensorDataset, ConcatDataset, IterableDataset
 
 
-def to_tfrecords(spectrograms, captions, fname="data.tfrecord"):
-    tfrecord_writer = tf.io.TFRecordWriter(fname)
-    for (spectrogram, caption) in zip(spectrograms, captions):
-        example = tf.train.Example(features=tf.train.Features(feature={
-            'audio': tf.train.Feature(float_list=tf.train.FloatList(value=spectrogram.flatten())),
-            'text': tf.train.Feature(int64_list=tf.train.Int64List(value=[*caption.encode('utf-8')])),
-        }))
-        tfrecord_writer.write(example.SerializeToString())
-
-    tfrecord_writer.close()
-
 class PairTextSpectrogramTFRecords(object):
     def __init__(self, local_or_gcs_path, batch_size, prefetch_size=0, mel_bins=80, max_audio_len=2048, max_text_len=256):
         self.mel_bins = mel_bins
@@ -52,6 +41,18 @@ class PairTextSpectrogramTFRecords(object):
 
         features_tensor = tf.io.parse_single_example(record, tfrecord_format)
         return features_tensor
+
+    @staticmethod
+    def write(spectrograms, captions, fname="data.tfrecord"):
+        tfrecord_writer = tf.io.TFRecordWriter(fname)
+        for (spectrogram, caption) in zip(spectrograms, captions):
+            example = tf.train.Example(features=tf.train.Features(feature={
+                'audio': tf.train.Feature(float_list=tf.train.FloatList(value=spectrogram.flatten())),
+                'text': tf.train.Feature(int64_list=tf.train.Int64List(value=[*caption.encode('utf-8')])),
+            }))
+            tfrecord_writer.write(example.SerializeToString())
+
+        tfrecord_writer.close()
     
 
 class PairTextSpectrogramDataset(Dataset):

--- a/clap/datasets.py
+++ b/clap/datasets.py
@@ -22,7 +22,7 @@ class PairTextSpectrogramTFRecords(object):
             'audio': (max_audio_len, mel_bins),
             'text': (max_text_len),
         })
-        dataset = dataset.map(self.unsqueeze_trailing)
+        #dataset = dataset.map(self.unsqueeze_trailing)
         dataset = dataset.prefetch(prefetch_size)
         dataset = dataset.as_numpy_iterator()
         self.dataset = dataset
@@ -35,7 +35,7 @@ class PairTextSpectrogramTFRecords(object):
 
     def deserialize_tf_record(self, record):
         tfrecord_format = {
-            'spectrogram': tf.io.FixedLenSequenceFeature((self.mel_bins,), dtype=tf.float32, allow_missing=True),
+            'audio': tf.io.FixedLenSequenceFeature((self.mel_bins,), dtype=tf.float32, allow_missing=True),
             'text': tf.io.FixedLenSequenceFeature([], dtype=tf.int64, allow_missing=True),
         }
 

--- a/clap/models.py
+++ b/clap/models.py
@@ -119,9 +119,7 @@ class CLAP(nn.Module):
         enc_audio = self.audio_encoder(audio, is_training=is_training)
         return enc_audio
 
-    def __call__(
-        self, text, audio, return_loss=True, is_training=False
-    ):
+    def __call__(self, text, audio, return_loss=True, is_training=False):
         b = text.shape[0]
 
         to_text_tokens = self.text_tokenizer

--- a/clap/models.py
+++ b/clap/models.py
@@ -111,18 +111,16 @@ class CLAP(nn.Module):
 
         self.temp = self.param("temperature", self.temp_init, tuple())
 
-    def encode_text(self, text, mask, is_training):
-        # Ignore mask, for now.
+    def encode_text(self, text, is_training):
         enc_text = self.text_encoder(text, is_training=is_training)
         return enc_text
 
-    def encode_audio(self, audio, mask, is_training):
-        # Ignore mask, for now.
+    def encode_audio(self, audio, is_training):
         enc_audio = self.audio_encoder(audio, is_training=is_training)
         return enc_audio
 
     def __call__(
-        self, text, audio, text_mask, audio_mask, return_loss=True, is_training=False
+        self, text, audio, return_loss=True, is_training=False
     ):
         b = text.shape[0]
 
@@ -130,8 +128,8 @@ class CLAP(nn.Module):
 
         text = to_text_tokens(text)
 
-        enc_text = self.encode_text(text, text_mask, is_training)
-        enc_audio = self.encode_audio(audio, audio_mask, is_training)
+        enc_text = self.encode_text(text, is_training)
+        enc_audio = self.encode_audio(audio, is_training)
 
         enc_text = enc_text / jnp.linalg.norm(enc_text, axis=-1, keepdims=True)
         enc_audio = enc_audio / jnp.linalg.norm(enc_audio, axis=-1, keepdims=True)

--- a/configs/preprocessing/dataset/commonvoice.yaml
+++ b/configs/preprocessing/dataset/commonvoice.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+data_folder: "./data"
+tsv_filename: 'subset.tsv'
+mel_bins: 80

--- a/preprocess.py
+++ b/preprocess.py
@@ -17,22 +17,24 @@ def tsv_to_dict(path):
 
 # script
 
-@hydra.main(config_path="preprocessing/configs")
-def train(cfg: DictConfig) -> None:
-    voice_clips = tsv_to_dict(f"{cfg.data_dir}/{cfg.tsv_filename}")
+@hydra.main(config_path="configs")
+def preprocess(cfg: DictConfig) -> None:
+    data_folder = hydra.utils.get_original_cwd() + "/" + cfg.preprocessing.dataset.data_folder
+
+    voice_clips = tsv_to_dict(f"{data_folder}/{cfg.preprocessing.dataset.tsv_filename}")
 
     def extract_spectrogram(filename):
-        waveform, sample_rate = torchaudio.load(f"{cfg.data_dir}/clips/{filename}")
+        waveform, sample_rate = torchaudio.load(f"{data_folder}/clips/{filename}")
 
         output = torchaudio.transforms.MelSpectrogram(
-            sample_rate, n_mels=cfg.mel_bins, f_min=0, f_max=8000
+            sample_rate, n_mels=cfg.preprocessing.dataset.mel_bins, f_min=0, f_max=8000
         )(waveform)[0]
 
         return output.t().numpy()
 
     spectrograms = (extract_spectrogram(clip['path']) for clip in voice_clips)
     captions = (clip['sentence'] for clip in voice_clips)
-    save_path = cfg.data_dir + '/data.tfrecord'
+    save_path = data_folder + '/data.tfrecord'
     PairTextSpectrogramTFRecords.write(spectrograms, captions, fname=save_path)
 
 if __name__ == "__main__":

--- a/preprocess.py
+++ b/preprocess.py
@@ -17,9 +17,12 @@ def tsv_to_dict(path):
 
 # script
 
+
 @hydra.main(config_path="configs")
 def preprocess(cfg: DictConfig) -> None:
-    data_folder = hydra.utils.get_original_cwd() + "/" + cfg.preprocessing.dataset.data_folder
+    data_folder = (
+        hydra.utils.get_original_cwd() + "/" + cfg.preprocessing.dataset.data_folder
+    )
 
     voice_clips = tsv_to_dict(f"{data_folder}/{cfg.preprocessing.dataset.tsv_filename}")
 
@@ -32,10 +35,11 @@ def preprocess(cfg: DictConfig) -> None:
 
         return output.t().numpy()
 
-    spectrograms = (extract_spectrogram(clip['path']) for clip in voice_clips)
-    captions = (clip['sentence'] for clip in voice_clips)
-    save_path = data_folder + '/data.tfrecord'
+    spectrograms = (extract_spectrogram(clip["path"]) for clip in voice_clips)
+    captions = (clip["sentence"] for clip in voice_clips)
+    save_path = data_folder + "/data.tfrecord"
     PairTextSpectrogramTFRecords.write(spectrograms, captions, fname=save_path)
+
 
 if __name__ == "__main__":
     preprocess()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "tensorflow",
         "torch",
         "torchaudio",
+        "tqdm",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "jaxlib",
         "lm_dataformat",
         "optax",
+        "tensorflow",
         "torch",
         "torchaudio",
     ],

--- a/train.py
+++ b/train.py
@@ -35,7 +35,7 @@ def train(cfg: DictConfig) -> None:
     dataloader = PairTextSpectrogramTFRecords(
         training_data_path,
         cfg.training.batch_size,
-        )
+    )
 
     # model
 
@@ -59,8 +59,8 @@ def train(cfg: DictConfig) -> None:
 
     batch = next(iter(dataloader))
 
-    text = batch['text']
-    audio = batch['audio']
+    text = batch["text"]
+    audio = batch["audio"]
 
     params = model.init(rng_key, text, audio)
     optim_state = optim.init(params)
@@ -82,8 +82,8 @@ def train(cfg: DictConfig) -> None:
 
     for _ in range(cfg.training.epochs):
         for batch in dataloader:
-            text = batch['text']
-            audio = batch['audio']
+            text = batch["text"]
+            audio = batch["audio"]
             loss, grads = loss_fn(params, text, audio)
             updates, optim_state = optim.update(grads, optim_state, params)
             params = apply_updates(params, updates)

--- a/train.py
+++ b/train.py
@@ -13,15 +13,13 @@ from optax import (
     masked,
 )
 
+from einops import rearrange, repeat
+
 from clap.models import CLAP
 
 # data
 
-from torch.utils.data import DataLoader
-from clap.datasets import (
-    pair_text_spectrogram_dataset_collate_fn,
-    PairTextSpectrogramDataset,
-)
+from clap.datasets import PairTextSpectrogramTFRecords
 
 
 @hydra.main(config_path="configs")
@@ -36,14 +34,10 @@ def train(cfg: DictConfig) -> None:
     # data
 
     training_data_path = hydra.utils.get_original_cwd() + "/" + cfg.training.data_folder
-    dataset = PairTextSpectrogramDataset(training_data_path)
-    dl = DataLoader(
-        dataset,
-        batch_size=cfg.training.batch_size,
-        collate_fn=pair_text_spectrogram_dataset_collate_fn,
-        drop_last=True,
-        shuffle=True,
-    )
+    dl = PairTextSpectrogramTFRecords(
+        training_data_path,
+        cfg.training.batch_size,
+        )
 
     # model
 
@@ -65,22 +59,23 @@ def train(cfg: DictConfig) -> None:
 
     # init
 
-    audio, audio_mask, text, text_mask = next(iter(dl))
+    batch = next(iter(dl))
 
-    params = model.init(rng_key, text, audio, text_mask, audio_mask)
+    text = batch['text']
+    audio = repeat(batch['audio'], "... -> ... ()")
+
+    params = model.init(rng_key, text, audio)
     optim_state = optim.init(params)
 
     # loss function, for use with value_and_grad
 
-    @jit
+    #@jit
     @value_and_grad
-    def loss_fn(params, text, audio, text_mask, audio_mask):
+    def loss_fn(params, text, audio):
         return model.apply(
             params,
             text,
             audio,
-            text_mask,
-            audio_mask,
             return_loss=True,
             is_training=True,
         )
@@ -88,8 +83,10 @@ def train(cfg: DictConfig) -> None:
     # train loop
 
     for _ in range(cfg.training.epochs):
-        for audio, audio_mask, text, text_mask in dl:
-            loss, grads = loss_fn(params, text, audio, text_mask, audio_mask)
+        for batch in dl:
+            text = batch['text']
+            audio = repeat(batch['audio'], "... -> ... ()")
+            loss, grads = loss_fn(params, text, audio)
             updates, optim_state = optim.update(grads, optim_state, params)
             params = apply_updates(params, updates)
             print(f"loss: {loss}")


### PR DESCRIPTION
Both `preprocess.py` and `train.py` now use TFRecords as the format for pre-processed data. Would close #25. Currently untested on GCP, but it works with TFRecords at local paths.